### PR TITLE
Support get document not found error and remove toMap entity method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ branches:
 jobs:
   include:
   - stage: compile
-    name: OracleJDK 8 / Build / Test
-    jdk: oraclejdk8
+    name: openjdk 8 / Build / Test
+    jdk: openjdk8
     script: mvn clean test install
 notifications:
   email:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 1.0.4
+### Feature
+* Support Jackson annotations in order to define data types and database field names
+* toMap Entity method is never required anymore.
+
+### Bugfix
+* handler GET document not found error
+
 ## 1.0.3
 ### Dependencies
 * Improve Readme

--- a/README.md
+++ b/README.md
@@ -141,6 +141,146 @@ public class VehicleRepository extends RxFirestoreSDK<Vehicle> {
 
 3. Add `GOOGLE_APPLICATION_CREDENTIALS` environment variable to your project, pointing to your keyfile.json
 4. *(Optional)* Add `DB_THREAD_POOL_SIZE` environment variable to your project. Default value is set to the amount of cores * 2.
+5. Create your entity model
+
+All entities must extend `Entity` interface and implements `getCollectionName` and `fromJsonAsMap`
+
+* getCollectionName: Must return you firestore collection name
+* fromJsonAsMap: will receive a JSON as a Map format and must return a Java entity
+
+Example:
+
+```
+/*
+ * Copyright 2019 RxFirestore.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.github.pjgg.rxfirestore;
+
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.vertx.core.json.Json;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+public class Vehicle implements Entity {
+
+	public final static String CARS_COLLECTION_NAME = "cars";
+	public final static String BRAND = "brand";
+	public final static String MODEL = "model";
+	public final static String ELECTRIC = "electric";
+	public final static String DISPLACEMENT = "displacement";
+
+	private String id;
+	private String eventType;
+
+	@JsonProperty(value="brandy")
+	private String brand;
+	private String model;
+	private Boolean electric;
+	private Number displacement;
+
+	@JsonFormat(shape = Shape.STRING, pattern = "dd-MM-yyyy hh:mm:ss")
+	private Date createdDate;
+
+	public Vehicle() {
+	}
+
+	public Vehicle(String brand, String model, Boolean electric) {
+		this.brand = brand;
+		this.model = model;
+		this.electric = electric;
+		this.displacement = 0;
+		this.createdDate = new Date();
+	}
+
+	@Override
+	public String getCollectionName() {
+		return CARS_COLLECTION_NAME;
+	}
+
+	@Override
+	public Entity fromJsonAsMap(Map<String, Object> json) {
+
+		this.brand = (String) json.getOrDefault(BRAND, "NONE");
+		this.model = (String) json.getOrDefault(MODEL, "NONE");
+		this.electric = (Boolean) json.getOrDefault(ELECTRIC, false);
+
+		this.displacement = (Number) json.getOrDefault("displacement", 0);
+		this.id = (String) json.getOrDefault("_id", "NONE");
+		this.eventType = (String) json.getOrDefault("_eventType", "NONE");
+
+		return this;
+	}
+
+	public String getBrand() {
+		return brand;
+	}
+
+	public void setBrand(String brand) {
+		this.brand = brand;
+	}
+
+	public String getModel() {
+		return model;
+	}
+
+	public void setModel(String model) {
+		this.model = model;
+	}
+
+	public Boolean getElectric() {
+		return electric;
+	}
+
+	public void setElectric(Boolean electric) {
+		this.electric = electric;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getEventType() {
+		return eventType;
+	}
+
+	public void setEventType(String eventType) {
+		this.eventType = eventType;
+	}
+
+	public Number getDisplacement() {
+		return displacement;
+	}
+
+	public void setDisplacement(Number displacement) {
+		this.displacement = displacement;
+	}
+}
+
+```
+
+
+*Note:* As you have notice we support Jackson annotations in order to define data types and field names.
 
 ## API methods
 
@@ -235,3 +375,4 @@ To delete a document, use the delete method. Deleting a document does not delete
 ```
 Single<Boolean> delete(final String id, final String collectionName)
 ```
+

--- a/src/main/java/com/github/pjgg/rxfirestore/Entity.java
+++ b/src/main/java/com/github/pjgg/rxfirestore/Entity.java
@@ -17,18 +17,21 @@
 
 package com.github.pjgg.rxfirestore;
 
+import io.vertx.core.json.Json;
 import java.util.HashMap;
 import java.util.Map;
 
 public interface Entity {
 
-	HashMap<String, Object> toMap();
-
 	String getCollectionName();
 
 	/**
 	 * Note that your will receive two extra fields _id and _eventType
-	 * */
+	 */
 	Entity fromJsonAsMap(Map<String, Object> json);
+
+	default String toJson() {
+		return Json.encode(this);
+	}
 
 }

--- a/src/main/java/com/github/pjgg/rxfirestore/SingleEntityCallbackHandler.java
+++ b/src/main/java/com/github/pjgg/rxfirestore/SingleEntityCallbackHandler.java
@@ -17,6 +17,7 @@
 
 package com.github.pjgg.rxfirestore;
 
+import com.github.pjgg.rxfirestore.exceptions.NotFoundExceptions;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import java.util.Map;
@@ -46,7 +47,7 @@ public class SingleEntityCallbackHandler implements ApiFutureCallback<DocumentSn
 			data.put("_id", Optional.ofNullable(document.getId()).orElse("NONE"));
 			entity.onSuccess(data);
 		} else {
-			entity.onError(new RuntimeException("Not Found"));
+			entity.onError(new NotFoundExceptions("Document Not found"));
 		}
 	}
 

--- a/src/main/java/com/github/pjgg/rxfirestore/exceptions/NotFoundExceptions.java
+++ b/src/main/java/com/github/pjgg/rxfirestore/exceptions/NotFoundExceptions.java
@@ -1,0 +1,10 @@
+package com.github.pjgg.rxfirestore.exceptions;
+
+public class NotFoundExceptions extends RxFirestoreExceptions {
+
+	public static final int NOT_FOUND_CODE = 2;
+
+	public NotFoundExceptions(String msg) {
+		super(NOT_FOUND_CODE, msg);
+	}
+}

--- a/src/main/java/com/github/pjgg/rxfirestore/exceptions/RxFirestoreExceptions.java
+++ b/src/main/java/com/github/pjgg/rxfirestore/exceptions/RxFirestoreExceptions.java
@@ -1,0 +1,16 @@
+package com.github.pjgg.rxfirestore.exceptions;
+
+public abstract class RxFirestoreExceptions extends RuntimeException {
+
+	private final int errorCode;
+	private final String msg;
+
+	public RxFirestoreExceptions(final int errorCode, final String msg) {
+		this.errorCode = errorCode;
+		this.msg = msg;
+	}
+
+	public int getErrorCode() {
+		return errorCode;
+	}
+}

--- a/src/test/java/com/github/pjgg/rxfirestore/RxFirestoreUpsertTest.java
+++ b/src/test/java/com/github/pjgg/rxfirestore/RxFirestoreUpsertTest.java
@@ -1,0 +1,107 @@
+package com.github.pjgg.rxfirestore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.reactivex.Observable;
+import io.reactivex.Single;
+import io.reactivex.observers.TestObserver;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import java.util.concurrent.TimeUnit;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(VertxExtension.class)
+public class RxFirestoreUpsertTest {
+
+	private final String brandName = "Toyota";
+	private VertxTestContext testContext;
+
+	@Before
+	public void clean_scenario() {
+		testContext = new VertxTestContext();
+
+		Query query = TestSuite.getInstance().vehicleRepository.queryBuilderSync(Vehicle.CARS_COLLECTION_NAME);
+		TestSuite.getInstance().vehicleRepository.get(query.whereEqualTo("brand", brandName)).blockingGet().forEach(vehicle -> {
+			TestSuite.getInstance().vehicleRepository.delete(vehicle.getId(), Vehicle.CARS_COLLECTION_NAME).blockingGet();
+		});
+	}
+
+	@Test
+	public void testshould_insert_car() throws InterruptedException {
+
+		TestObserver<Boolean> testObserver = new TestObserver();
+		String expectedModel = "Auris_updated";
+		Vehicle vehicle = new Vehicle(brandName, "Auris", true);
+		Single<Boolean> isUpdated = TestSuite.getInstance().vehicleRepository.upsert("001", Vehicle.CARS_COLLECTION_NAME, vehicle);
+
+		Observable<Boolean> result = Observable.fromFuture(isUpdated.toFuture());
+		result.subscribe(testObserver);
+
+		testObserver.assertComplete();
+		testObserver.assertNoErrors();
+		testObserver.assertNever(r -> {
+			testContext.completeNow();
+			return r == false;
+		});
+
+		assertThat(testContext.awaitCompletion(1, TimeUnit.SECONDS)).isTrue();
+
+		// check that is properly stored
+		TestObserver<Vehicle> vehicleObserver = new TestObserver();
+		Observable<Vehicle> r = Observable.fromFuture(TestSuite.getInstance().vehicleRepository.get("001", Vehicle.CARS_COLLECTION_NAME).toFuture());
+		r.subscribe(vehicleObserver);
+
+		vehicleObserver.assertComplete();
+		vehicleObserver.assertNoErrors();
+		vehicleObserver.assertValue(re -> {
+			testContext.completeNow();
+			return re.getId().equalsIgnoreCase("001");
+		});
+
+		assertThat(testContext.awaitCompletion(1, TimeUnit.SECONDS)).isTrue();
+	}
+
+	@Test
+	public void testshould_upsert_car() throws InterruptedException {
+
+		TestObserver<Boolean> testObserver = new TestObserver();
+		String expectedModel = "Auris_updated";
+		Vehicle vehicle = new Vehicle(brandName, "Auris", true);
+		Single<Boolean> isUpdated = TestSuite.getInstance().vehicleRepository.upsert("002", Vehicle.CARS_COLLECTION_NAME, vehicle).flatMap( isInsertedVehicle -> {
+			if(isInsertedVehicle) {
+				vehicle.setModel("Auris_updated");
+				return TestSuite.getInstance().vehicleRepository.upsert("002", Vehicle.CARS_COLLECTION_NAME, vehicle);
+			}
+
+			return Single.just(false);
+		});
+
+		Observable<Boolean> result = Observable.fromFuture(isUpdated.toFuture());
+		result.subscribe(testObserver);
+
+		testObserver.assertComplete();
+		testObserver.assertNoErrors();
+		testObserver.assertNever(r -> {
+			testContext.completeNow();
+			return r == false;
+		});
+
+		assertThat(testContext.awaitCompletion(1, TimeUnit.SECONDS)).isTrue();
+
+		// check that is properly stored
+		TestObserver<Vehicle> vehicleObserver = new TestObserver();
+		Observable<Vehicle> r = Observable.fromFuture(TestSuite.getInstance().vehicleRepository.get("002", Vehicle.CARS_COLLECTION_NAME).toFuture());
+		r.subscribe(vehicleObserver);
+
+		vehicleObserver.assertComplete();
+		vehicleObserver.assertNoErrors();
+		vehicleObserver.assertValue(re -> {
+			testContext.completeNow();
+			return re.getModel().equalsIgnoreCase("Auris_updated");
+		});
+
+		assertThat(testContext.awaitCompletion(1, TimeUnit.SECONDS)).isTrue();
+	}
+}

--- a/src/test/java/com/github/pjgg/rxfirestore/Vehicle.java
+++ b/src/test/java/com/github/pjgg/rxfirestore/Vehicle.java
@@ -17,8 +17,13 @@
 
 package com.github.pjgg.rxfirestore;
 
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.vertx.core.json.Json;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonFormat;
 
 public class Vehicle implements Entity {
 
@@ -28,13 +33,15 @@ public class Vehicle implements Entity {
 	public final static String ELECTRIC = "electric";
 	public final static String DISPLACEMENT = "displacement";
 
-
 	private String id;
 	private String eventType;
 	private String brand;
 	private String model;
 	private Boolean electric;
 	private Number displacement;
+
+	@JsonFormat(shape = Shape.STRING, pattern = "dd-MM-yyyy hh:mm:ss")
+	private Date createdDate;
 
 	public Vehicle() {
 	}
@@ -44,16 +51,7 @@ public class Vehicle implements Entity {
 		this.model = model;
 		this.electric = electric;
 		this.displacement = 0;
-	}
-
-	@Override
-	public HashMap<String, Object> toMap() {
-		return new HashMap<String, Object>() {{
-			put(BRAND, brand);
-			put(MODEL, model);
-			put(ELECTRIC, electric);
-			put(DISPLACEMENT, displacement);
-		}};
+		this.createdDate = new Date();
 	}
 
 	@Override


### PR DESCRIPTION
### What's the focus of this PR?
* Remove toMap entity method
* Support not found error when you try to retrieve a random document by Id

### How to review this PR?
All test still valid.

### Related Issues
NO

### Has breaking changes?
Yes. toMap method was removed.

### Definition of Done
- [X] Feature unit tested
- [X] There is no outcommented or debug code left (if there is a good reason, use a // FIXME: comment or // TODO: comment and create a follow-up tasks)
- [X] Documented in the CHANGELOG.md file
