### PR TITLE
Use google applicationDefault credentials instead of keyfile

### DIFF
--- a/src/main/java/com/github/pjgg/rxfirestore/BlockingFirestoreTemplate.java
+++ b/src/main/java/com/github/pjgg/rxfirestore/BlockingFirestoreTemplate.java
@@ -53,16 +53,17 @@ public class BlockingFirestoreTemplate<E extends Entity> {
 		supplier = Objects.requireNonNull(entityConstructor);
 		this.vertx = vertxSubject;
 
+
 		try {
-
-			String keyPath = Optional.ofNullable(System.getenv("GOOGLE_APPLICATION_CREDENTIALS")).orElseThrow(
-					() -> new IllegalArgumentException("GOOGLE_APPLICATION_CREDENTIALS is not set in the environment"));
-
-			firestore = FirestoreOptions.newBuilder().setCredentials(
-					GoogleCredentials.fromStream(new FileInputStream(new File(keyPath))).createScoped(
-						FirestoreTemplate.SCOPES)).build()
-					.getService();
-
+			firestore = FirestoreOptions.newBuilder()
+					/*
+					* See for further information about authentication
+					* https://cloud.google.com/docs/authentication/production
+					* In order to use different project-id than the one defined in applicationDefaultCredentials
+					* you can use GCLOUD_PROJECT environment variable 
+					*/
+					.setCredentials(GoogleCredentials.getApplicationDefault().createScoped(FirestoreTemplate.SCOPES))
+					.build().getService();
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}

--- a/src/main/java/com/github/pjgg/rxfirestore/FirestoreTemplate.java
+++ b/src/main/java/com/github/pjgg/rxfirestore/FirestoreTemplate.java
@@ -72,16 +72,15 @@ public class FirestoreTemplate extends AbstractVerticle {
 	public FirestoreTemplate() {
 
 		try {
-
-			String keyPath = Optional.ofNullable(System.getenv("GOOGLE_APPLICATION_CREDENTIALS")).orElseThrow(
-				() -> new IllegalArgumentException("GOOGLE_APPLICATION_CREDENTIALS is not set in the environment"));
-
-			firestore = FirestoreOptions.newBuilder().setCredentials(
-				GoogleCredentials.fromStream(new FileInputStream(new File(keyPath))).createScoped(SCOPES)).build()
-				.getService();
-
-			LOG.trace("GOOGLE_APPLICATION_CREDENTIALS located -> " + keyPath);
-
+			firestore = FirestoreOptions.newBuilder()
+					/*
+					* See for further information about authentication
+					* https://cloud.google.com/docs/authentication/production
+					* In order to use different project-id than the one defined in applicationDefaultCredentials
+					* you can use GCLOUD_PROJECT environment variable 
+					*/
+					.setCredentials(GoogleCredentials.getApplicationDefault().createScoped(FirestoreTemplate.SCOPES))
+					.build().getService();
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}


### PR DESCRIPTION
Google provides getApplicationDefault() that automatically reads
credentials. If running in a development station it will use credentials
configured with gcloud.
If running in GCE instance, it will use instance's credentials.
If running in GKE you can use Workload Identity[1]

Additionally, you can use well known environment variables to change the getApplicationDefault() behaviour[2]:
- `GOOGLE_APPLICATION_CREDENTIALS`: if the variable is set, ADC uses the service account file that the variable points to.
- `GCLOUD_PROJECT`: if the variable si set, ADC uses this as project id.

[1] https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
[2] https://cloud.google.com/docs/authentication/productio